### PR TITLE
making use of pypact reading for density

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         shell: bash -el {0}
         run: |
             conda install -c conda-forge "openmc>=0.15.2" jupyter
-            python -m pip install pypact
+            python -m pip install git+https://github.com/fispact/pypact
             python download_fns_fusion_decay.py
             mkdir -p ~/nuclear_data
             wget -q -O - https://anl.box.com/shared/static/uhbxlrx7hvxqw27psymfbhi7bx7s6u6a.xz | tar -C ~/nuclear_data -xJ

--- a/compare.ipynb
+++ b/compare.ipynb
@@ -11,7 +11,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,8 +21,7 @@
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import openmc\n",
-    "import openmc.deplete\n",
-    "import pypact as pp  # can be installed with pip install pypact\n",
+    "import pypact as pp  # needs latest version which can be installed with pip install git+https://github.com/fispact/pypact\n",
     "\n",
     "from openmc_activator import OpenmcActivator"
    ]


### PR DESCRIPTION
Recently I added the ability for pypact to read the density keyword from a fispact input file
https://github.com/fispact/pypact/pull/59

we can now make use of this in the script and save some lines of code

this code block
```
def read_density(filepath):
     lines = open(filepath).readlines()
     for line in lines:
         spl = line.strip().split()
         if 'DENSITY' in line:
             assert('DENSITY' == spl[0])
             return float(spl[1])
     raise ValueError('Density not found')
 ```
can be replaced by this
```
def read_density(filepath):
     ff = pp.InputData()
     pp.from_file(ff, filepath)
     return ff._density
```