### PR TITLE
adding standard python gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+fnz.zip
+fns/


### PR DESCRIPTION
this is auto generated by github when making a new python repo.

I have also added a couple of things to this so fns data is included